### PR TITLE
[Feat] book search api connection

### DIFF
--- a/ReadLog/ReadLog.xcodeproj/project.pbxproj
+++ b/ReadLog/ReadLog.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 		E6E68EDF2AF1DD7C00172557 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E6E68EDE2AF1DD7C00172557 /* Assets.xcassets */; };
 		E6E68EE22AF1DD7C00172557 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E6E68EE12AF1DD7C00172557 /* Preview Assets.xcassets */; };
 		E6F5AD1E2B0FCAFC00A605D4 /* ISBNScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F5AD1D2B0FCAFC00A605D4 /* ISBNScannerView.swift */; };
+		E6F5AD252B112AEE00A605D4 /* BookInfoData_Temporal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F5AD242B112AEE00A605D4 /* BookInfoData_Temporal.swift */; };
+		E6F5AD272B113B8D00A605D4 /* APIResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F5AD262B113B8D00A605D4 /* APIResponse.swift */; };
+		E6F5AD2A2B134C0200A605D4 /* URLImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F5AD292B134C0200A605D4 /* URLImage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -72,6 +75,9 @@
 		E6E68EDE2AF1DD7C00172557 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E6E68EE12AF1DD7C00172557 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		E6F5AD1D2B0FCAFC00A605D4 /* ISBNScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISBNScannerView.swift; sourceTree = "<group>"; };
+		E6F5AD242B112AEE00A605D4 /* BookInfoData_Temporal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfoData_Temporal.swift; sourceTree = "<group>"; };
+		E6F5AD262B113B8D00A605D4 /* APIResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResponse.swift; sourceTree = "<group>"; };
+		E6F5AD292B134C0200A605D4 /* URLImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLImage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,6 +121,7 @@
 		E60DDA972B0A8CCF00F25BB2 /* SearchBook */ = {
 			isa = PBXGroup;
 			children = (
+				E6F5AD1F2B10699D00A605D4 /* BookSearchAPI */,
 				E6F5AD1C2B0FCA9200A605D4 /* BarcodeScanner */,
 				E60DDA982B0A8D1400F25BB2 /* BookSearchView.swift */,
 				E60DDA9A2B0A8F2400F25BB2 /* SearchBar.swift */,
@@ -202,6 +209,7 @@
 		E6E68EE82AF1DDF400172557 /* Presenter */ = {
 			isa = PBXGroup;
 			children = (
+				E6F5AD282B134BEC00A605D4 /* URLImage */,
 				E6035B882B0CF07F00C34007 /* BookShelf */,
 				E6035B852B0CEF4200C34007 /* ReadingBook */,
 				9DC96E9D2B0C57B500034878 /* BookDetail */,
@@ -281,6 +289,23 @@
 				E6F5AD1D2B0FCAFC00A605D4 /* ISBNScannerView.swift */,
 			);
 			path = BarcodeScanner;
+			sourceTree = "<group>";
+		};
+		E6F5AD1F2B10699D00A605D4 /* BookSearchAPI */ = {
+			isa = PBXGroup;
+			children = (
+				E6F5AD242B112AEE00A605D4 /* BookInfoData_Temporal.swift */,
+				E6F5AD262B113B8D00A605D4 /* APIResponse.swift */,
+			);
+			path = BookSearchAPI;
+			sourceTree = "<group>";
+		};
+		E6F5AD282B134BEC00A605D4 /* URLImage */ = {
+			isa = PBXGroup;
+			children = (
+				E6F5AD292B134C0200A605D4 /* URLImage.swift */,
+			);
+			path = URLImage;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -371,6 +396,8 @@
 				9DA3579C2B009AD1004EC3C1 /* viewBookMemo.swift in Sources */,
 				DB633C1B2B02FC8F004CEC27 /* Model.xcdatamodeld in Sources */,
 				DB18172D2B062ED600A55F80 /* Persistence.swift in Sources */,
+				E6F5AD2A2B134C0200A605D4 /* URLImage.swift in Sources */,
+				E6F5AD252B112AEE00A605D4 /* BookInfoData_Temporal.swift in Sources */,
 				E61851832B0B9EA80067811C /* APIKEY.swift in Sources */,
 				E6187EF62B03505300731321 /* TextRecognizer.swift in Sources */,
 				E60025092B06378D00C4DFDD /* Date+Extension.swift in Sources */,
@@ -379,6 +406,7 @@
 				E62252702AFB7E7000D33EC3 /* TextStyle+Extension.swift in Sources */,
 				E6E68EDB2AF1DD7B00172557 /* ReadLogApp.swift in Sources */,
 				E6035B872B0CEF5600C34007 /* ReadingBookView.swift in Sources */,
+				E6F5AD272B113B8D00A605D4 /* APIResponse.swift in Sources */,
 				E6E4BF562B01BF4000FEEE10 /* Header.swift in Sources */,
 				E6E4BF532B01B70300FEEE10 /* AddNoteView.swift in Sources */,
 				E6035B8A2B0CF09200C34007 /* BookShelfView.swift in Sources */,

--- a/ReadLog/ReadLog/Info.plist
+++ b/ReadLog/ReadLog/Info.plist
@@ -2,10 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>책의 내용을 스캔하기 위해서 카메라 사용 허용이 필요합니다.</string>
-
 	<key>UIAppFonts</key>
 	<array>
 		<string>omyu pretty.ttf</string>

--- a/ReadLog/ReadLog/Presenter/BookInfo/BookInfoView.swift
+++ b/ReadLog/ReadLog/Presenter/BookInfo/BookInfoView.swift
@@ -9,14 +9,16 @@ import SwiftUI
 
 struct BookInfoView: View {
     // later change into binding variables (take data from BookSearchView's selection)
-    @State var bookTitle: String = "책 제목"
-    @State var bookAuthor: String = "작가"
-    @State var bookPublisher: String = "출판사"
-    @State var bookNthCycle: Int = 1
-    @State var bookIntroduce: String = 
-        """
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nec dapibus augue. Aliquam ut fermentum metus, ut volutpat sapien. Nunc cursus felis convallis nulla ornare, a gravida diam efficitur. Mauris odio eros, egestas vitae mollis eu, mattis vel diam. Donec nec porttitor nisl. Fusce risus diam, consequat eget magna congue, pretium cursus sem. Fusce sollicitudin pretium erat sodales vulputate. Vivamus sed viverra magna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Morbi ligula nulla, elementum luctus volutpat id, convallis vitae nunc.
-        """
+//    @State var bookTitle: String = "책 제목"
+//    @State var bookAuthor: String = "작가"
+//    @State var bookPublisher: String = "출판사"
+//    @State var bookNthCycle: Int = 1
+//    @State var bookIntroduce: String = 
+//        """
+//        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nec dapibus augue. Aliquam ut fermentum metus, ut volutpat sapien. Nunc cursus felis convallis nulla ornare, a gravida diam efficitur. Mauris odio eros, egestas vitae mollis eu, mattis vel diam. Donec nec porttitor nisl. Fusce risus diam, consequat eget magna congue, pretium cursus sem. Fusce sollicitudin pretium erat sodales vulputate. Vivamus sed viverra magna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Morbi ligula nulla, elementum luctus volutpat id, convallis vitae nunc.
+//        """
+    
+    @Binding var bookInfo: BookInfoData_Temporal
     
     @State var like = false
     
@@ -24,7 +26,8 @@ struct BookInfoView: View {
         NavigationStack {
             VStack {
                 ScrollView {
-                    BookProfileContainer(bookTitle: $bookTitle, bookAuthor: $bookAuthor, bookPublisher: $bookPublisher, bookNthCycle: $bookNthCycle)
+//                    BookProfileContainer(bookTitle: $bookTitle, bookAuthor: $bookAuthor, bookPublisher: $bookPublisher, bookNthCycle: $bookNthCycle)
+                    BookProfileContainer(bookInfo: $bookInfo)
                         .padding(.horizontal, 20)
                     
                     HStack {
@@ -41,7 +44,7 @@ struct BookInfoView: View {
                     
                     Divider()
                     
-                    Text(bookIntroduce)
+                    Text(bookInfo.description)
                         .padding(.vertical, 15)
                         .padding(.horizontal)
                         .lineSpacing(20)
@@ -82,6 +85,6 @@ struct BookInfoView: View {
     }
 }
 
-#Preview {
-    BookInfoView()
-}
+//#Preview {
+//    BookInfoView()
+//}

--- a/ReadLog/ReadLog/Presenter/SearchBook/BookProfileContainer.swift
+++ b/ReadLog/ReadLog/Presenter/SearchBook/BookProfileContainer.swift
@@ -7,11 +7,17 @@
 
 import SwiftUI
 
+
 struct BookProfileContainer: View {
-    @Binding var bookTitle: String
-    @Binding var bookAuthor: String
-    @Binding var bookPublisher: String
-    @Binding var bookNthCycle: Int
+//    @Binding var bookTitle: String
+//    @Binding var bookAuthor: String
+//    @Binding var bookPublisher: String
+//    @Binding var bookNthCycle: Int
+    
+    @Binding var bookInfo: BookInfoData_Temporal
+    
+    // set bookNthCycle to 0 temporarily
+    var bookNthCycle = 0
     
     
     
@@ -19,19 +25,27 @@ struct BookProfileContainer: View {
         let frameHeight: CGFloat = bookNthCycle != 0 ? 200.0 : 150.0
         
         HStack {
-            Image(systemName: "book")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 100)
-                .clipped()
-                .padding(.horizontal, 15)
+//            Image(systemName: "book")
+//                .resizable()
+//                .scaledToFit()
+//                .frame(width: 100)
+//                .clipped()
+//                .padding(.horizontal, 15)
+            URLImage(urlString: bookInfo.coverImage)
             
             VStack(alignment: .leading) {
-                Text(bookTitle)
+//                Text(bookTitle)
+//                    .padding(.vertical, 6)
+//                Text(bookAuthor)
+//                    .padding(.vertical, 6)
+//                Text(bookPublisher)
+//                    .padding(.vertical, 6)
+                
+                Text(bookInfo.title)
                     .padding(.vertical, 6)
-                Text(bookAuthor)
+                Text(bookInfo.author)
                     .padding(.vertical, 6)
-                Text(bookPublisher)
+                Text(bookInfo.publisher)
                     .padding(.vertical, 6)
                 
                 if bookNthCycle != 0 {
@@ -54,13 +68,15 @@ struct BookProfileContainer: View {
         .padding(.vertical, 8)
         .padding(.horizontal)
     }
+    
+    
 }
 
-#Preview {
-    BookProfileContainer(
-        bookTitle: Binding.constant("책 제목"),
-        bookAuthor: Binding.constant("작가"),
-        bookPublisher: Binding.constant("출판사"),
-        bookNthCycle: Binding.constant(1)
-    )
-}
+//#Preview {
+//    BookProfileContainer(
+//        bookTitle: Binding.constant("책 제목"),
+//        bookAuthor: Binding.constant("작가"),
+//        bookPublisher: Binding.constant("출판사"),
+//        bookNthCycle: Binding.constant(1)
+//    )
+//}

--- a/ReadLog/ReadLog/Presenter/SearchBook/BookSearchAPI/APIResponse.swift
+++ b/ReadLog/ReadLog/Presenter/SearchBook/BookSearchAPI/APIResponse.swift
@@ -1,0 +1,27 @@
+//
+//  APIResponse.swift
+//  ReadLog
+//
+//  Created by 유석원 on 11/25/23.
+//
+
+import Foundation
+
+struct APIResponse: Codable {
+    let version: String
+    let logo: String
+    let title: String
+    let link: String
+    let pubDate: String
+    let totalResults: Int
+    let startIndex: Int
+    let itemsPerPage: Int
+    let query: String
+    let searchCategoryId: Int
+    let searchCategoryName: String
+    let item: [BookInfoData_Temporal]
+    
+//    private enum CodingKeys: String, CodingKey {
+//        case 
+//    }
+}

--- a/ReadLog/ReadLog/Presenter/SearchBook/BookSearchAPI/BookInfoData_Temporal.swift
+++ b/ReadLog/ReadLog/Presenter/SearchBook/BookSearchAPI/BookInfoData_Temporal.swift
@@ -1,0 +1,48 @@
+//
+//  BookInfoData_Temporal.swift
+//  ReadLog
+//
+//  Created by 유석원 on 11/25/23.
+//
+
+import Foundation
+
+struct BookInfoData_Temporal: Codable, Identifiable {
+    let id: Int
+    let isbn: String
+    let isbn13: String
+    let title: String
+    let author: String
+    let pubDate: String
+    let description: String
+    let coverImage: String
+    let publisher: String
+    let priceStandard: Int
+    
+//    let link: String
+//    let priceSales: Int
+//    let mallType: String
+//    let stockStatus: String
+//    let mileage: Int
+//    let categoryId: Int
+//    let categoryName: String
+//    let salesPoint: Int
+//    let adult: Bool
+//    let fixedPrice: Bool
+//    let customerReviewRank: Int
+//    let seriesInfo // object
+//    let subInfo // object
+    
+    private enum CodingKeys: String, CodingKey {
+        case id = "itemId"
+        case isbn
+        case isbn13
+        case title
+        case author
+        case pubDate
+        case description
+        case coverImage = "cover"
+        case publisher
+        case priceStandard
+    }
+}

--- a/ReadLog/ReadLog/Presenter/SearchBook/SearchBar.swift
+++ b/ReadLog/ReadLog/Presenter/SearchBook/SearchBar.swift
@@ -9,14 +9,18 @@ import SwiftUI
 
 struct SearchBar: View {
     @Binding var text: String
+    var fetchData: (String) -> Void
     
     var body: some View {
         HStack {
             HStack {
 //                Image(systemName: "magnifyingglass")
                 
-                TextField("책 제목, 작가, 출판사", text: $text)
-                    .foregroundColor(.primary)
+                TextField("책 제목, 작가, 출판사", text: $text, onCommit: {
+                    let request = "http://www.aladin.co.kr/ttb/api/ItemSearch.aspx?ttbkey=\(ApiKey.aladinKey)&Query=\(text)&QueryType=Keyword&MaxResults=10&start=1&SearchTarget=Book&output=js&Version=20131101"
+                    fetchData(request)
+                })
+                .foregroundColor(.primary)
                 
                 if !text.isEmpty {
                     Button(action: {

--- a/ReadLog/ReadLog/Presenter/URLImage/URLImage.swift
+++ b/ReadLog/ReadLog/Presenter/URLImage/URLImage.swift
@@ -1,0 +1,49 @@
+//
+//  URLImage.swift
+//  ReadLog
+//
+//  Created by 유석원 on 11/26/23.
+//
+
+import SwiftUI
+
+struct URLImage: View {
+    let urlString: String?
+    @State var data: Data?
+    
+    var body: some View {
+        if let data = data, let uiImage = UIImage(data: data) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 100)
+                .clipped()
+                .padding(.horizontal, 15)
+        } else {
+            Image(systemName: "book")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 100)
+                .clipped()
+                .padding(.horizontal, 15)
+                .onAppear {
+                    fetchImageData()
+                }
+        }
+    }
+    
+    private func fetchImageData() {
+        guard let urlString = urlString else {
+            return
+        }
+        
+        guard let url = URL(string: urlString) else {
+            return
+        }
+        
+        let task = URLSession.shared.dataTask(with: url) { data, _, _ in
+            self.data = data
+        }
+        task.resume()
+    }
+}

--- a/ReadLog/ReadLog/System/ReadLogApp.swift
+++ b/ReadLog/ReadLog/System/ReadLogApp.swift
@@ -11,8 +11,8 @@ import SwiftUI
 struct ReadLogApp: App {
     var body: some Scene {
         WindowGroup {
-//            ContentView()
-            BookSearchView()
+            ContentView()
+//            BookSearchView()
         }
     }
 }


### PR DESCRIPTION
Uses aladin book search api to find the book data. Text search is "Keyword" searching, and barcode search is "ISBN" searching. It receives json data (including cover image) and stores it to BookInfoData_Temporal structure. Shows the search result into list.

# 이슈 번호
🔒 Close #37 

## 구현 / 변경 사항 이유
알라딘 Open API를 사용하여 책의 데이터를 받아온다.
검색창에서 검색 할 경우, "Keyword" 검색으로, 책 제목, 작가, 출판사 등의 키워드 검색 결과를 json 데이터로 받아온다.
바코드에서 검색 할 경우, 바코드를 읽어와 ISBN을 알아낸 뒤, ISBN으로 검색을 실시해 json 데이터를 받아온다.
현재 core data가 완벽하게 연결되어 있지 않은 관계로, 임시의 구조체 "BookInfoData_Temporal"로 json 데이터를 파싱해 사용하고 있다.
검색창에서 검색을 실시할 때, 버튼을 클릭하거나 키보드의 return 버튼을 누르면 키보드가 내려가면서 검색 결과를 불러오도록 구현했다.
NavigationLink를 클릭하면 BookInfoView로 넘어가, 상세 정보를 볼 수 있게 구현했다.

<img width="250" src="">

## 리뷰 포인트

## 기타 사항
현재 이유는 모르겠으나 실행을 한 뒤 검색창에 텍스트를 입력하려 할 때 약 2초간 버벅거린다.

일단 총 검색 결과의 상위 10개의 결과만 나오도록 구현해두었다.
다른 앱에서도 보여주듯 10개에서 20개의 검색 결과를 보면 다음 검색 결과를 로딩 할 수 있게 설정해야 할 것 같다.

현재 책의 상세 정보 뷰로 이동했을 때 텍스트가 길면 ...으로 잘린 모습을 볼 수 있다.
또한 책의 이미지가 화질이 좋지 않다.
추후에 전체 테마를 적용하면서 고쳐야 할 것 같다.

이미 검색을 한 번 하고 결과물이 있는 상태에서 다른 검색을 하면 뷰의 새로고침이 되도록 고쳐야 할 것 같다.

## References
https://docs.google.com/document/d/1mX-WxuoGs8Hy-QalhHcvuV17n50uGI2Sg_GHofgiePE/edit

