### PR TITLE
[Fix] removed blank isbn item from search result

### DIFF
--- a/ReadLog/ReadLog/Presenter/SearchBook/BookSearchAPI/PaginationViewModel.swift
+++ b/ReadLog/ReadLog/Presenter/SearchBook/BookSearchAPI/PaginationViewModel.swift
@@ -72,9 +72,10 @@ class PaginationViewModel: ObservableObject {
                 
                 DispatchQueue.main.async {
                     print(decodedData.item.count)
-                    
-                    let bookDataArray: [BookInfoData] = decodedData.item.map { bookData in
+                    let filteredData = decodedData.item.filter { $0.isbn != "" }
+                    let bookDataArray: [BookInfoData] = filteredData.map { bookData in
                         if let itemPage = bookData.subInfo?.itemPage {
+                            
                             let bookData = BookInfoData(
                                 id: bookData.id,
                                 isbn: bookData.isbn,


### PR DESCRIPTION
Item with blank isbn is not shown in search result.

# 이슈 번호
🔒 Close #73 

## 구현 / 변경 사항 이유
ISBN이 없는 아이템을 검색 결과에서 제외시킨다.

<img width="250" src="">

## 리뷰 포인트

## 기타 사항
구현하면서 고민되었던 부분이나 질문 사항 등

## References


