### PR TITLE
[Fix] BookInfoView to CoreData save bug fixed

### DIFF
--- a/ReadLog/ReadLog/Presenter/BookInfo/BookInfoView.swift
+++ b/ReadLog/ReadLog/Presenter/BookInfo/BookInfoView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 import CoreData
 
 struct BookInfoView: View {
-    // core data
-    @Environment(\.managedObjectContext) private var viewContext
     @Environment(\.dismiss) var dismiss
     @Binding var tab: Int
     
+    // core data
+    @Environment(\.managedObjectContext) private var viewContext
     @FetchRequest(
         sortDescriptors: [
             NSSortDescriptor(keyPath: \BookInfo.id, ascending: false)
@@ -21,8 +21,6 @@ struct BookInfoView: View {
         animation: .default
     )
     private var dbBookData: FetchedResults<BookInfo>
-    
-    @State private var bookDataFromDB: BookInfo?
     
     // view variables
     var bookInfo: BookInfoData
@@ -86,6 +84,7 @@ struct BookInfoView: View {
                         if buttonText == "독서 시작" {
                             Button {
                                 print("start to read the book.")
+                                dbBookData.nsPredicate = NSPredicate(format: "id == %d", Int32(bookInfo.id))
                                 if dbBookData.isEmpty {
                                     // if bookInfo object has page number, api call is not required.
                                     if bookInfo.itemPage != 0 {
@@ -157,17 +156,13 @@ struct BookInfoView: View {
                     }
                     
                 }
-                
-                if let book = dbBookData.first {
-                    self.bookDataFromDB = book
-                }
             }
         }
         .onDisappear {
             // save wishlist changes
             // if book data is not in db and added to wishlist, saves book data (wish = true)
             // if book data is in db, save changes
-            
+            dbBookData.nsPredicate = NSPredicate(format: "id == %d", Int32(bookInfo.id))
             if dbBookData.isEmpty {
                 if like {
                     if bookInfo.itemPage == 0 {


### PR DESCRIPTION
Saving book data from BookInfoView to CoreData now works properly. CoreData query was the problem.

# 이슈 번호
🔒 Close #76 

## 구현 / 변경 사항 이유
BookInfoView에서 CoreData로 저장이 제대로 되지 않는 문제 해결.
첫 저장은 제대로 된 뒤에, 다른 저장이 제대로 안 되는 것으로 보아 DB query에 문제가 있었을 것으로 추정 됨.
Breakpoint를 걸고 확인해보면 분명 DB에 저장되어 있지 않은 책이지만, dbBookData.isEmpty가 false로 나오는 것을 알 수 있음.
onAppear에서만 nsPredicate를 걸어줬는데 지속적으로 쿼리가 작동하지 않는 듯함.
따라서 dbBookData.isEmpty를 확인 하기 전에 매번 nsPredicate를 설정해주는 것으로 버그 해결.

<img width="250" src="">

## 리뷰 포인트

## 기타 사항
구현하면서 고민되었던 부분이나 질문 사항 등

## References


